### PR TITLE
fix: 1 .fix tree_set/tree_map end iterator 2. delete duplicated cmake_minimum_required macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
 project(ronleeon-adt CXX)
-cmake_minimum_required(VERSION 3.15)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(${CMAKE_SOURCE_DIR})
 add_subdirectory(test)

--- a/ronleeon/tree/tree_map.h
+++ b/ronleeon/tree/tree_map.h
@@ -95,10 +95,14 @@ namespace ronleeon{
 			}
 
 			reference operator*() const 
-			{ return node->data;}
+			{ 
+				return node->data;
+			}
 
 			pointer operator->() const
-			{ return &(node->data); }
+			{ 	 
+				return &(node->data); 
+			}
 
 
 
@@ -189,6 +193,9 @@ namespace ronleeon{
 			}
 
 			typename Tree::const_node_pointer tree_map_increment(typename Tree::const_node_pointer value) const {
+				if(value == this_end){
+					return start;
+				}
 				auto Next = Tree::increment(value);
 				if(!Next){
 					return this_end;
@@ -198,7 +205,7 @@ namespace ronleeon{
 
 
 			typename Tree::const_node_pointer tree_map_decrement(typename Tree::const_node_pointer value) const {
-				if(value == reinterpret_cast<typename Tree::const_node_pointer>(this)){
+				if(value == this_end){
 					return last;
 				}
 				auto Pre = Tree::decrement(value);

--- a/ronleeon/tree/tree_set.h
+++ b/ronleeon/tree/tree_set.h
@@ -33,10 +33,14 @@ namespace ronleeon::tree{
 		}
 
 		reference operator*() const
-		{ return node->data;}
+		{ 
+			return node->data;
+		}
 
 		pointer operator->() const
-		{ return &(node->data); }
+		{
+			return &(node->data); 
+		}
 
 
 		tree_set_iterator& operator++()
@@ -123,6 +127,9 @@ namespace ronleeon::tree{
 		}
 
 		typename Tree::const_node_pointer tree_set_increment(typename Tree::const_node_pointer value) const {
+			if(value == this_end){
+				return start;
+			}
 			auto Next = Tree::increment(value);
 			if(!Next){
 				return this_end;
@@ -132,14 +139,14 @@ namespace ronleeon::tree{
 
 
 		typename Tree::const_node_pointer tree_set_decrement(typename Tree::const_node_pointer value) const {
-			if(value == reinterpret_cast<typename Tree::const_node_pointer>(this)){
-					return last;
-				}
-				auto Pre = Tree::decrement(value);
-				if(!Pre){
-					return this_end;
-				}
-				return Pre;
+			if(value == this_end){
+				return last;
+			}
+			auto Pre = Tree::decrement(value);
+			if(!Pre){
+				return this_end;
+			}
+			return Pre;
 		}
 
 

--- a/test/testSet.h
+++ b/test/testSet.h
@@ -14,7 +14,7 @@ void testSet() {
 	for(auto It = set.rbegin();It != set.rend(); ++It){
 		std::cout<<*It<<'\n';
 	}
-	set.clear();
+	//set.clear();
 	ronleeon::tree::tree_map<int,int,ronleeon::tree::less<ronleeon::tree::pair<int,int>>,ronleeon::tree::rb_tree<ronleeon::tree::pair<int,int>
 	,ronleeon::tree::less<ronleeon::tree::pair<int,int>>>> m;
 	m.insert(1,2);
@@ -28,4 +28,6 @@ void testSet() {
 	for(auto It = m.rbegin();It != m.rend(); ++It){
 		std::cout<<It->first<<","<<It->second<<'\n';
 	}
+	std::cout<<*(++set.rend())<<'\n';
+	std::cout<<(--m.end())->first<<","<<(--m.end())->second<<'\n';
 }


### PR DESCRIPTION
1. fix tree_set/tree_map end iterator error, cause incorrect output when --end()/--rend(), according to the stanand, take back from an end iterator returns the last element of the relevant sequence
2. delete a duplicated cmake_minimum_required(VERSION 3.15) macro